### PR TITLE
Fixes a bug that causes problems with uppercase table names

### DIFF
--- a/dumper/mysql.go
+++ b/dumper/mysql.go
@@ -95,7 +95,7 @@ func (d *mySQL) GetColumnsForSelect(table string) (columns []string, err error) 
 		return
 	}
 	for k, column := range columns {
-		replacement, ok := d.SelectMap[table][column]
+		replacement, ok := d.SelectMap[strings.ToLower(table)][column]
 		if ok {
 			columns[k] = fmt.Sprintf("%s AS `%s`", replacement, column)
 		} else {
@@ -112,7 +112,7 @@ func (d *mySQL) GetSelectQueryFor(table string) (query string, err error) {
 		return "", err
 	}
 	query = fmt.Sprintf("SELECT %s FROM `%s`", strings.Join(cols, ", "), table)
-	if where, ok := d.WhereMap[table]; ok {
+	if where, ok := d.WhereMap[strings.ToLower(table)]; ok {
 		query = fmt.Sprintf("%s WHERE %s", query, where)
 	}
 	return
@@ -120,8 +120,9 @@ func (d *mySQL) GetSelectQueryFor(table string) (query string, err error) {
 
 // Get the number of rows the select will return
 func (d *mySQL) GetRowCount(table string) (count uint64, err error) {
+
 	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`", table)
-	if where, ok := d.WhereMap[table]; ok {
+	if where, ok := d.WhereMap[strings.ToLower(table)]; ok {
 		query = fmt.Sprintf("%s WHERE %s", query, where)
 	}
 	row := d.DB.QueryRow(query)
@@ -220,8 +221,9 @@ func (d *mySQL) Dump(w io.Writer) (err error) {
 	}
 
 	for _, table := range tables {
-		if d.FilterMap[table] != "ignore" {
-			skipData := d.FilterMap[table] == "nodata"
+		
+		if d.FilterMap[strings.ToLower(table)] != "ignore" {
+			skipData := d.FilterMap[strings.ToLower(table)] == "nodata"
 			if !skipData && d.UseTableLock {
 				d.LockTableReading(table)
 				d.FlushTable(table)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/hgfischer/mysqlsuperdump/dumper"
+	"github.com/dadacafe/mysqlsuperdump/dumper"
 )
 
 func main() {


### PR DESCRIPTION
Hi!

I encountered a problem with this tool if the table names contains uppercase letters. It looks to me that that the table names included in the config file will always get read as lowercase and therefore entries in filters, where sections etc are not treated at all.

I am not a go-pro and I am not sure if the fix works on all platforms but I thought it would be nice for you to know that this issue exists. 