### PR TITLE
Add support for allowlist filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ using more resources from the server to run, until it exploded.
 * Replace dumped data with native SELECT functions (`[select]` config's section)
 * Disable data output of specific tables (`[filter]` config's section: `nodata`)
 * Ignore entire tables (`[filter]` config's section: `ignore`)
+* Ignore all tables except those explicitly listed (`[filter]` config's `* = ignore` and section: `include`)
 
 
 ## Usage
@@ -91,6 +92,26 @@ system_dump_version.created_at = NOW()
 [filter]
 customer_stats = nodata
 customer_private = ignore
+```
+
+If you would like to have an allowlist of explicitly listed tables, you can put
+the following in your `[filter]` section:
+```
+[filter]
+* = ignore
+customer_address = include
+customer = include
+sales_order_address = include
+system_dump_version = include
+```
+
+The same can be done for `nodata`:
+```
+[filter]
+# All tables are data only by default
+* = nodata
+# But include the data for the customer table
+customer = include
 ```
 
 ## TO DO

--- a/dumper/mysql.go
+++ b/dumper/mysql.go
@@ -219,14 +219,16 @@ func (d *mySQL) Dump(w io.Writer) (err error) {
 		return
 	}
 
+	globalFilter := d.FilterMap["*"]
 	for _, table := range tables {
-		if d.FilterMap[strings.ToLower(table)] == "ignore" {
+		tableFilter := d.FilterMap[strings.ToLower(table)]
+
+		if tableFilter == "ignore" || (tableFilter == "" && globalFilter == "ignore") {
 			continue
 		}
-		if d.FilterMap[strings.ToLower(table)] == "" && d.FilterMap["*"] == "ignore" {
-			continue
-		}
-		skipData := d.FilterMap[strings.ToLower(table)] == "nodata"
+
+		skipData := tableFilter == "nodata" || (tableFilter == "" && globalFilter == "nodata")
+
 		if !skipData && d.UseTableLock {
 			d.LockTableReading(table)
 			d.FlushTable(table)


### PR DESCRIPTION
Currently it is not possible to exclude unknown tables. This change allows tables to be explicitly listed so that only those tables will be dumped.

For example, the following will only export the customer table.

```
[filter]
* = ignore
customer = include
```

(The existing code is hardly touched, this is mostly just additions. However, one line is slightly refactored to early-exit, so the remaining code in the function ends up being de-indented.)